### PR TITLE
Patch to properly handle situation where a git commit has an empty file set

### DIFF
--- a/lib/vclog/adapters/git.rb
+++ b/lib/vclog/adapters/git.rb
@@ -37,7 +37,11 @@ module VCLog
         changes.each do |entry|
           date, who, id, msg, files = entry.split(RUBY_FIELD_MARKER)
           date  = Time.parse(date)
-          files = files.split("\n")
+          if files.nil?
+            files = [ "" ]
+          else
+            files = files.split("\n")
+          end
           list << Change.new(:id=>id, :date=>date, :who=>who, :msg=>msg, :files=>files)
         end
 
@@ -178,7 +182,11 @@ module VCLog
 
         who = who + ' ' + email
         date  = Time.parse(date)
-        files = files.split("\n")
+        if files.nil?
+          files = [ "" ]
+        else
+          files = files.split("\n")
+        end
 
         return { :date=>date, :who=>who, :id=>id, :message=>msg, :files=>files }
       end


### PR DESCRIPTION
Should a git commit contain no file changes, a situation which is
possible when the git repository has been converted from another SCM
system such as Subversion, then assign an empty string to the list of
files.

This will prevent an exception caused when ruby tries to split a Nil
object.

Tested against git 1.8.0.1 and ruby 1.9.3
